### PR TITLE
Update Vesktop version and use wildcards.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/

--- a/dev.vencord.vesktop.yml
+++ b/dev.vencord.vesktop.yml
@@ -30,8 +30,8 @@ modules:
   - name: vesktop
     buildsystem: simple
     build-commands:
-      - chmod +x Vesktop-0.3.2.AppImage
-      - ./Vesktop-0.3.2.AppImage --appimage-extract
+      - chmod +x Vesktop-*.AppImage
+      - ./Vesktop-*.AppImage --appimage-extract
 
       - install -dm755 "${FLATPAK_DEST}/bin" "${FLATPAK_DEST}/lib/vesktop"
       - cp -r squashfs-root/* "${FLATPAK_DEST}/lib/vesktop"
@@ -44,8 +44,8 @@ modules:
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo dev.vencord.vesktop.metainfo.xml
     sources:
       - type: file
-        url: https://github.com/Vencord/Vesktop/releases/download/v0.3.2/Vesktop-0.3.2.AppImage
-        sha256: 10a2a710dd16abc36e8a78b51d4410e8eaf83c2ec8e6c11a60abb2a99620095e
+        url: https://github.com/Vencord/Vesktop/releases/download/v0.3.3/Vesktop-0.3.3.AppImage
+        sha256: 5c311d867d331f291037bdccc4dea45196e96a562308ec7434ff54faec6bed32 
       - type: file
         path: dev.vencord.vesktop.metainfo.xml
       - type: file

--- a/dev.vencord.vesktop.yml
+++ b/dev.vencord.vesktop.yml
@@ -44,8 +44,11 @@ modules:
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo dev.vencord.vesktop.metainfo.xml
     sources:
       - type: file
-        url: https://github.com/Vencord/Vesktop/releases/download/v0.3.3/Vesktop-0.3.3.AppImage
-        sha256: 5c311d867d331f291037bdccc4dea45196e96a562308ec7434ff54faec6bed32 
+        url: https://github.com/Vencord/Vesktop/releases/download/v0.3.2/Vesktop-0.3.2.AppImage
+        sha512: 5c311d867d331f291037bdccc4dea45196e96a562308ec7434ff54faec6bed32
+        x-checker-data:
+          type: electron-updater
+          url: https://github.com/Vencord/Vesktop/releases/latest/download/latest-linux.yml
       - type: file
         path: dev.vencord.vesktop.metainfo.xml
       - type: file

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "automerge-flathubbot-prs": true
 }


### PR DESCRIPTION
Use wildcards so that you need to change less lines when you update the version.
x-checker data updates the files when needed, test on your local machine with
```sh
flatpak install --from https://dl.flathub.org/repo/appstream/org.flathub.flatpak-external-data-checker.flatpakref
flatpak run --filesystem=<project-dir> org.flathub.flatpak-external-data-checker <project-dir>/<manifest> --update --commit-only
```