### PR TITLE
Close <release> tag and remove ampersand.

### DIFF
--- a/dev.vencord.Vesktop.metainfo.xml
+++ b/dev.vencord.Vesktop.metainfo.xml
@@ -22,17 +22,21 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
+  
   <releases>
+    
   <release version="0.4.3" date="2023-11-01">
    <description>
     <ul>
     
      <li>MacOS: fix positioning of traffic lights by @pupbrained in #185</li>
-     <li>SteamOS: fixes & official controller layout by @AAGaming00 in #194</li>
+     <li>SteamOS: fixes and official controller layout by @AAGaming00 in #194</li>
      <li>linux: audio screenshare should now also work on less up to date distros</li>
     
      </ul>
    </description>
+  </release>
+    
   <release version="0.4.2" date="2023-10-27">
    <description>
     <ul>


### PR DESCRIPTION
Flatpak complains about the ampersand and unclosed <release> tag. It really doesn't like the ampersand. 